### PR TITLE
[WIP] Add Mac OS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ gimli={git="https://github.com/fitzgen/gimli.git"}
 elf = "0.0.9"
 log = "0.3.6"
 env_logger = "0.3.4"
+mach = "0.0.5"
 
 [dev-dependencies]
 flate2 = "0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ elf = "0.0.9"
 log = "0.3.6"
 env_logger = "0.3.4"
 mach = "0.0.5"
+libproc = "0.1.0"
+object = "0.1.0"
 
 [dev-dependencies]
 flate2 = "0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ env_logger = "0.3.4"
 mach = "0.0.5"
 libproc = "0.1.0"
 object = "0.1.0"
+libarchive = "0.1.1"
+libarchive3-sys = "0.1.2"
 
 [dev-dependencies]
 flate2 = "0.2.14"

--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -410,7 +410,6 @@ mod obj {
             if !name.ends_with(".o") {
                 continue
             }
-            println!("Reading entries from '{}'", name);
 
             let file_entries = get_entries_from_file(buf);
             entries.extend(file_entries);
@@ -445,7 +444,7 @@ mod obj {
         let path = guess_ruby_path(pid);
 
         if path.extension().unwrap() == "a" {
-            println!("Using archive '{}'", path.to_str().unwrap());
+            debug!("Using archive '{}'", path.to_str().unwrap());
             get_archive_entries(path)
         } else {
             let file = open(path);

--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -7,7 +7,7 @@ use byteorder::{NativeEndian, ReadBytesExt};
 use std::collections::HashMap;
 use std::io::Cursor;
 
-pub use self::obj::get_dwarf_entries;
+pub use self::obj::{get_executable_path, get_dwarf_entries};
 
 type HashMapFnv<K, V> = HashMap<K, V, BuildHasherDefault<FnvHasher>>;
 
@@ -284,6 +284,10 @@ mod obj {
     /// The parsed object file type.
     type File = elf::File;
 
+    pub fn get_executable_path(pid: usize) -> Result<PathBuf, String> {
+        Ok(PathBuf::from(format!("/proc/{}/exe", pid)))
+    }
+
     pub fn get_dwarf_entries(pid: usize) -> Vec<Entry> {
         let file_path = format!("/proc/{}/exe", pid);
         let file = open(&file_path);
@@ -364,8 +368,7 @@ mod obj {
     /// executable binary. However there's often a `libruby-static.a` nearby
     /// in the file system that *does* have DWARF info in it.
     fn guess_ruby_path(pid: usize) -> PathBuf {
-        let exec_path = libproc::libproc::proc_pid::pidpath(pid as i32).expect("Could not look up path for PID");
-        let exec_path = PathBuf::from(&exec_path);
+        let exec_path = get_executable_path(pid).expect("Could not look up path for PID");
 
         let static_path = exec_path.join("../../lib/libruby-static.a").canonicalize()
             .expect("Could not guess libruby-static.a path");
@@ -380,7 +383,7 @@ mod obj {
     /// Scans a static archive (`.a` file in the semi-standard `ar` format)
     /// for `.o` object files. It then reads all the entries from each of
     /// those files.
-    pub fn get_archive_entries<P>(path: P) -> Vec<Entry>
+    fn get_archive_entries<P>(path: P) -> Vec<Entry>
         where P: AsRef<Path>
     {
         let builder = reader::Builder::new();
@@ -416,18 +419,6 @@ mod obj {
         entries
     }
 
-    pub fn get_dwarf_entries(pid: usize) -> Vec<Entry> {
-        let path = guess_ruby_path(pid);
-
-        if path.extension().unwrap() == "a" {
-            println!("Using archive '{}'", path.to_str().unwrap());
-            get_archive_entries(path)
-        } else {
-            let file = open(path);
-            get_entries_from_file(file)
-        }
-    }
-
     fn get_entries_from_file(file: Vec<u8>) -> Vec<Entry> {
         let file = object::File::parse(&file);
 
@@ -442,6 +433,23 @@ mod obj {
             get_all_entries::<gimli::LittleEndian>(debug_info, debug_abbrev, debug_str)
         } else {
             get_all_entries::<gimli::BigEndian>(debug_info, debug_abbrev, debug_str)
+        }
+    }
+
+    pub fn get_executable_path(pid: usize) -> Result<PathBuf, String> {
+        libproc::libproc::proc_pid::pidpath(pid as i32)
+            .map(|path| PathBuf::from(&path))
+    }
+
+    pub fn get_dwarf_entries(pid: usize) -> Vec<Entry> {
+        let path = guess_ruby_path(pid);
+
+        if path.extension().unwrap() == "a" {
+            println!("Using archive '{}'", path.to_str().unwrap());
+            get_archive_entries(path)
+        } else {
+            let file = open(path);
+            get_entries_from_file(file)
         }
     }
 }

--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -11,7 +11,7 @@ type HashMapFnv<K, V> = HashMap<K, V, BuildHasherDefault<FnvHasher>>;
 
 
 fn get_attr_name<Endian>(die: &gimli::DebuggingInformationEntry<Endian>, debug_str: gimli::DebugStr<Endian>) -> Option<String>
-where Endian: gimli::Endianity 
+where Endian: gimli::Endianity
 {
     let mut attrs = die.attrs();
     while let Some(attr) = attrs.next().expect("Should parse attribute OK") {
@@ -35,7 +35,7 @@ where Endian: gimli::Endianity
             },
             _ => continue,
         }
-    } 
+    }
     None
 }
 
@@ -45,7 +45,7 @@ fn read_pointer_address(vec: &[u8]) -> usize {
 }
 
 fn get_attr_byte_size<Endian>(die: &gimli::DebuggingInformationEntry<Endian>) -> Option<usize>
-where Endian: gimli::Endianity 
+where Endian: gimli::Endianity
 {
     let mut attrs = die.attrs();
     while let Some(attr) = attrs.next().expect("Should parse attribute OK") {
@@ -57,12 +57,12 @@ where Endian: gimli::Endianity
             },
             _ => continue,
         }
-    } 
+    }
     None
 }
 
 fn get_attr_type<Endian>(die: &gimli::DebuggingInformationEntry<Endian>) -> Option<usize>
-where Endian: gimli::Endianity 
+where Endian: gimli::Endianity
 {
     let mut attrs = die.attrs();
     while let Some(attr) = attrs.next().expect("Should parse attribute OK") {
@@ -74,13 +74,13 @@ where Endian: gimli::Endianity
             },
             _ => continue,
         }
-    } 
+    }
     None
 }
 
 
 fn get_data_member_location<Endian>(die: &gimli::DebuggingInformationEntry<Endian>) -> Option<usize>
-where Endian: gimli::Endianity 
+where Endian: gimli::Endianity
 {
     let mut attrs = die.attrs();
     while let Some(attr) = attrs.next().expect("Should parse attribute OK") {
@@ -105,7 +105,7 @@ where Endian: gimli::Endianity
 
 fn get_entry_list<Endian>(mut entries: gimli::EntriesCursor<Endian>, group_id: u32, debug_str: gimli::DebugStr<Endian>) -> Vec<(isize, Entry)>
     where Endian: gimli::Endianity
-{ 
+{
     let mut vec: Vec<(isize, Entry)> = Vec::new();
     while let Some((delta_depth, die)) = entries.next_dfs().expect("Should parse next dfs") {
         let entry = Entry {
@@ -137,7 +137,7 @@ pub struct Entry {
 
 
 pub struct DwarfLookup<'a> {
-    lookup_table: HashMapFnv<(usize, u32), &'a Entry>, 
+    lookup_table: HashMapFnv<(usize, u32), &'a Entry>,
     name_lookup: HashMapFnv<String, (usize, u32)>,
 }
 

--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -7,8 +7,9 @@ use byteorder::{NativeEndian, ReadBytesExt};
 use std::collections::HashMap;
 use std::io::Cursor;
 
-type HashMapFnv<K, V> = HashMap<K, V, BuildHasherDefault<FnvHasher>>;
+pub use self::obj::get_dwarf_entries;
 
+type HashMapFnv<K, V> = HashMap<K, V, BuildHasherDefault<FnvHasher>>;
 
 fn get_attr_name<Endian>(die: &gimli::DebuggingInformationEntry<Endian>, debug_str: gimli::DebugStr<Endian>) -> Option<String>
 where Endian: gimli::Endianity
@@ -272,34 +273,37 @@ fn index_name(name_lookup: &mut HashMapFnv<String, (usize, u32)>, entry: &Entry)
     }
 }
 
-
-pub fn get_dwarf_entries(pid: usize) -> Vec<Entry> {
-    let file_path = format!("/proc/{}/exe", pid);
-    let file = obj::open(&file_path);
-
-    let debug_info = obj::get_section(&file, ".debug_info")
-        .expect("Does not have .debug_info section");
-    let debug_abbrev = obj::get_section(&file, ".debug_abbrev")
-        .expect("Does not have .debug_abbrev section");
-    let debug_str = obj::get_section(&file, ".debug_str")
-        .expect("Does not have .debug_str section");
-
-    if obj::is_little_endian(&file) {
-        get_all_entries::<gimli::LittleEndian>(debug_info, debug_abbrev, debug_str)
-    } else {
-        get_all_entries::<gimli::BigEndian>(debug_info, debug_abbrev, debug_str)
-    }
-}
-
+#[cfg(target_os="linux")]
 mod obj {
     extern crate elf;
+
     use std::path::Path;
 
+    use super::Entry;
+
     /// The parsed object file type.
-    pub type File = elf::File;
+    type File = elf::File;
+
+    pub fn get_dwarf_entries(pid: usize) -> Vec<Entry> {
+        let file_path = format!("/proc/{}/exe", pid);
+        let file = open(&file_path);
+
+        let debug_info = get_section(&file, ".debug_info")
+            .expect("Does not have .debug_info section");
+        let debug_abbrev = get_section(&file, ".debug_abbrev")
+            .expect("Does not have .debug_abbrev section");
+        let debug_str = get_section(&file, ".debug_str")
+            .expect("Does not have .debug_str section");
+
+        if is_little_endian(&file) {
+            get_all_entries::<gimli::LittleEndian>(debug_info, debug_abbrev, debug_str)
+        } else {
+            get_all_entries::<gimli::BigEndian>(debug_info, debug_abbrev, debug_str)
+        }
+    }
 
     /// Open and parse the object file at the given path.
-    pub fn open<P>(path: P) -> File
+    fn open<P>(path: P) -> File
         where P: AsRef<Path>
     {
         let path = path.as_ref();
@@ -308,7 +312,7 @@ mod obj {
 
     /// Get the contents of the section named `section_name`, if such
     /// a section exists.
-    pub fn get_section<'a>(file: &'a File, section_name: &str) -> Option<&'a [u8]> {
+    fn get_section<'a>(file: &'a File, section_name: &str) -> Option<&'a [u8]> {
         file.sections
             .iter()
             .find(|s| s.shdr.name == section_name)
@@ -316,11 +320,55 @@ mod obj {
     }
 
     /// Return true if the file is little endian, false if it is big endian.
-    pub fn is_little_endian(file: &File) -> bool {
+    fn is_little_endian(file: &File) -> bool {
         match file.ehdr.data {
             elf::types::ELFDATA2LSB => true,
             elf::types::ELFDATA2MSB => false,
             otherwise => panic!("Unknown endianity: {}", otherwise),
+        }
+    }
+}
+
+#[cfg(target_os="macos")]
+mod obj {
+    extern crate gimli;
+    extern crate libproc;
+    extern crate object;
+
+    use self::object::Object;
+    use std::fs;
+    use std::io::Read;
+    use std::path::Path;
+
+    use super::{Entry, get_all_entries};
+
+    type File = Vec<u8>;
+
+    fn open<P>(path: P) -> File
+        where P: AsRef<Path>
+    {
+        let mut file = fs::File::open(path).expect("Could not open file");
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).expect("Could not read file");
+        buf
+    }
+
+    pub fn get_dwarf_entries(pid: usize) -> Vec<Entry> {
+        let path = libproc::libproc::proc_pid::pidpath(pid as i32).expect("Could not look up path for PID");
+        let file = open(path);
+        let file = object::File::parse(&file);
+
+        let debug_info = file.get_section(".debug_info")
+            .expect("Does not have .debug_info section");
+        let debug_abbrev = file.get_section(".debug_abbrev")
+            .expect("Does not have .debug_abbrev section");
+        let debug_str = file.get_section(".debug_str")
+            .expect("Does not have .debug_str section");
+
+        if file.is_little_endian() {
+            get_all_entries::<gimli::LittleEndian>(debug_info, debug_abbrev, debug_str)
+        } else {
+            get_all_entries::<gimli::BigEndian>(debug_info, debug_abbrev, debug_str)
         }
     }
 }

--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -291,8 +291,6 @@ pub fn get_dwarf_entries(pid: usize) -> Vec<Entry> {
     }
 }
 
-
-#[cfg(target_os="linux")]
 mod obj {
     extern crate elf;
     use std::path::Path;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,7 +407,7 @@ mod tests {
     use dwarf::{DwarfLookup, Entry, get_all_entries, create_lookup_table};
 
     use super::{DwarfTypes, get_types, get_stack_trace};
-    
+
     lazy_static! {
         static ref ENTRIES: Vec<Entry> = {
             get_all_entries::<LittleEndian>(DEBUG_INFO, DEBUG_ABBREV, DEBUG_STR)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,8 +146,9 @@ pub fn copy_address_raw<T>(addr: *const c_void, length: usize, source: &T) -> Ve
     }
     let mut copy = vec![0; length];
 
-    if source.copy_address(addr as usize, &mut copy).is_err() {
-        warn!("copy_address failed for {:p}", addr);
+    let res = source.copy_address(addr as usize, &mut copy);
+    if res.is_err() {
+        warn!("copy_address failed for {:p}: {:?}", addr, res.unwrap_err());
     }
 
     copy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,8 +174,9 @@ pub fn copy_address_raw<T>(addr: *const c_void, length: usize, source: &T) -> Ve
 //
 
 fn get_nm_address(pid: pid_t) -> u64 {
+    let exe = dwarf::get_executable_path(pid as usize).unwrap();
     let nm_command = Command::new("nm")
-        .arg(format!("/proc/{}/exe", pid))
+        .arg(exe)
         .stdout(Stdio::piped())
         .stdin(Stdio::null())
         .stderr(Stdio::piped())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ fn get_nm_address(pid: pid_t) -> u64 {
     }
 
     let nm_output = String::from_utf8(nm_command.stdout).unwrap();
-    let re = Regex::new(r"(\w+) b ruby_current_thread").unwrap();
+    let re = Regex::new(r"(\w+) [bs] _?ruby_current_thread").unwrap();
     let cap = re.captures(&nm_output).unwrap_or_else(|| {
         println!("Error: Couldn't find current thread in Ruby process. This is probably because \
                   either this isn't a Ruby process or you have a Ruby version compiled with no \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,9 +178,13 @@ fn get_nm_address(pid: pid_t) -> u64 {
         .arg(format!("/proc/{}/exe", pid))
         .stdout(Stdio::piped())
         .stdin(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .output()
         .unwrap_or_else(|e| panic!("failed to execute process: {}", e));
+    if !nm_command.status.success() {
+        panic!("failed to execute process: {}", String::from_utf8(nm_command.stderr).unwrap())
+    }
+
     let nm_output = String::from_utf8(nm_command.stdout).unwrap();
     let re = Regex::new(r"(\w+) b ruby_current_thread").unwrap();
     let cap = re.captures(&nm_output).unwrap_or_else(|| {
@@ -200,9 +204,13 @@ fn get_maps_address(pid: pid_t) -> u64 {
         .arg(format!("/proc/{}/maps", pid))
         .stdout(Stdio::piped())
         .stdin(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .output()
         .unwrap_or_else(|e| panic!("failed to execute process: {}", e));
+    if !cat_command.status.success() {
+        panic!("failed to execute process: {}", String::from_utf8(cat_command.stderr).unwrap())
+    }
+
     let output = String::from_utf8(cat_command.stdout).unwrap();
     let re = Regex::new(r"(\w+).+xp.+?bin/ruby").unwrap();
     let cap = re.captures(&output).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,7 @@ fn get_nm_address(pid: pid_t) -> u64 {
     addr
 }
 
+#[cfg(target_os="linux")]
 fn get_maps_address(pid: pid_t) -> u64 {
     let cat_command = Command::new("cat")
         .arg(format!("/proc/{}/maps", pid))
@@ -216,6 +217,37 @@ fn get_maps_address(pid: pid_t) -> u64 {
     let output = String::from_utf8(cat_command.stdout).unwrap();
     let re = Regex::new(r"(\w+).+xp.+?bin/ruby").unwrap();
     let cap = re.captures(&output).unwrap();
+    let address_str = cap.at(1).unwrap();
+    let addr = u64::from_str_radix(address_str, 16).unwrap();
+    debug!("get_maps_address: {:x}", addr);
+    addr
+}
+
+use std::iter::Iterator;
+
+#[cfg(target_os="macos")]
+fn get_maps_address(pid: pid_t) -> u64 {
+    let vmmap_command = Command::new("vmmap")
+        .arg(format!("{}", pid))
+        .stdout(Stdio::piped())
+        .stdin(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap_or_else(|e| panic!("failed to execute process: {}", e));
+    if !vmmap_command.status.success() {
+        panic!("failed to execute process: {}", String::from_utf8(vmmap_command.stderr).unwrap())
+    }
+
+    let output = String::from_utf8(vmmap_command.stdout).unwrap();
+
+    let lines: Vec<&str> = output.split("\n")
+        .filter(|line| line.contains("bin/ruby"))
+        .filter(|line| line.contains("__TEXT"))
+        .collect();
+    let line = lines.first().expect("No `__TEXT` line found for `bin/ruby` in vmmap output");
+
+    let re = Regex::new(r"([0-9a-f]+)").unwrap();
+    let cap = re.captures(&line).unwrap();
     let address_str = cap.at(1).unwrap();
     let addr = u64::from_str_radix(address_str, 16).unwrap();
     debug!("get_maps_address: {:x}", addr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,31 +51,93 @@ impl Process {
     }
 }
 
-impl CopyAddress for Process {
-    fn copy_address(&self, addr: usize, buf: &mut [u8]) -> io::Result<()> {
-        let local_iov = iovec {
-            iov_base: buf.as_mut_ptr() as *mut c_void,
-            iov_len: buf.len(),
-        };
-        let remote_iov = iovec {
-            iov_base: addr as *mut c_void,
-            iov_len: buf.len(),
-        };
-        unsafe {
-            let result = process_vm_readv(self.pid, &local_iov, 1, &remote_iov, 1, 0);
-            if result == -1 {
-                if !READ_EVER_SUCCEEDED {
-                    println!("Failed to read from pid {}. Are you root?", self.pid);
-                    process::exit(1);
-                } else {
-                    return Err(io::Error::last_os_error());
+#[cfg(target_os="linux")]
+mod platform {
+    use std::io;
+
+    use super::{CopyAddress, Process};
+
+    impl CopyAddress for Process {
+        fn copy_address(&self, addr: usize, buf: &mut [u8]) -> io::Result<()> {
+            let local_iov = iovec {
+                iov_base: buf.as_mut_ptr() as *mut c_void,
+                iov_len: buf.len(),
+            };
+            let remote_iov = iovec {
+                iov_base: addr as *mut c_void,
+                iov_len: buf.len(),
+            };
+            unsafe {
+                let result = process_vm_readv(self.pid, &local_iov, 1, &remote_iov, 1, 0);
+                if result == -1 {
+                    if !READ_EVER_SUCCEEDED {
+                        println!("Failed to read from pid {}. Are you root?", self.pid);
+                        process::exit(1);
+                    } else {
+                        return Err(io::Error::last_os_error());
+                    }
                 }
+                READ_EVER_SUCCEEDED = true;
             }
-            READ_EVER_SUCCEEDED = true;
+            Ok(())
         }
-        Ok(())
     }
 }
+
+#[cfg(target_os="macos")]
+mod platform {
+    extern crate libc;
+    extern crate mach;
+
+    use self::mach::kern_return::{kern_return_t, KERN_SUCCESS};
+    use self::mach::port::{mach_port_t, mach_port_name_t, MACH_PORT_NULL};
+    use self::mach::types::task_t;
+    use self::mach::vm_types::{mach_vm_address_t, mach_vm_size_t, vm_map_address_t};
+    use self::mach::message::{mach_msg_type_number_t};
+    use std::io;
+    use std::ptr;
+
+    use super::{CopyAddress, Process};
+
+    type vm_map_t = mach_port_t;
+
+    fn safe_task_for_pid(addr: libc::c_int) -> io::Result<mach_port_name_t> {
+        let mut task: mach_port_name_t = MACH_PORT_NULL;
+
+        unsafe {
+            let result = mach::traps::task_for_pid(mach::traps::mach_task_self(), addr as libc::c_int, &mut task);
+            if result != KERN_SUCCESS {
+                return Err(io::Error::last_os_error())
+            }
+        }
+
+        Ok(task)
+    }
+
+    extern "C" {
+        pub fn vm_read(target_task: vm_map_t, address: mach_vm_address_t, size: mach_vm_size_t, data: *mut [u8], data_size: *mut mach_msg_type_number_t) -> kern_return_t;
+    }
+
+    impl CopyAddress for Process {
+        fn copy_address(&self, addr: usize, buf: &mut [u8]) -> io::Result<()> {
+            let task = safe_task_for_pid(self.pid);
+            if task.is_err() { return task.map(|_| ()) }
+
+            unsafe {
+                let mut read: mach_msg_type_number_t = 0;
+
+                let result = vm_read(task.unwrap(), addr as u64, buf.len() as u64, buf, &mut read);
+                if result != KERN_SUCCESS {
+                    return Err(io::Error::last_os_error())
+                }
+            }
+
+            Ok(())
+        }
+    }
+}
+
+use platform::*;
 
 pub fn copy_address_raw<T>(addr: *const c_void, length: usize, source: &T) -> Vec<u8>
     where T: CopyAddress

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,21 +94,24 @@ mod platform {
     use self::mach::vm_types::{mach_vm_address_t, mach_vm_size_t};
     use self::mach::message::{mach_msg_type_number_t};
     use std::io;
+    use std::ptr;
+    use std::slice;
 
     use super::{CopyAddress, Process};
 
-    #[allow(non_camel_case_types)]
-    type vm_map_t = mach_port_t;
+    #[allow(non_camel_case_types)] type vm_map_t = mach_port_t;
+    #[allow(non_camel_case_types)] type vm_address_t = mach_vm_address_t;
+    #[allow(non_camel_case_types)] type vm_size_t = mach_vm_size_t;
 
     extern "C" {
-        fn vm_read(target_task: vm_map_t, address: mach_vm_address_t, size: mach_vm_size_t, data: *mut u8, data_size: *mut mach_msg_type_number_t) -> kern_return_t;
+        fn vm_read(target_task: vm_map_t, address: vm_address_t, size: vm_size_t, data: &*mut u8, data_size: *mut mach_msg_type_number_t) -> kern_return_t;
     }
 
-    fn task_for_pid(addr: libc::c_int) -> io::Result<mach_port_name_t> {
+    fn task_for_pid(pid: libc::c_int) -> io::Result<mach_port_name_t> {
         let mut task: mach_port_name_t = MACH_PORT_NULL;
 
         unsafe {
-            let result = mach::traps::task_for_pid(mach::traps::mach_task_self(), addr as libc::c_int, &mut task);
+            let result = mach::traps::task_for_pid(mach::traps::mach_task_self(), pid, &mut task);
             if result != KERN_SUCCESS {
                 return Err(io::Error::last_os_error())
             }
@@ -122,14 +125,31 @@ mod platform {
             let task = task_for_pid(self.pid);
             if task.is_err() { return task.map(|_| ()) }
 
-            unsafe {
-                let mut read: mach_msg_type_number_t = 0;
+            let page_addr      = (addr as i64 & (-4096)) as mach_vm_address_t;
+	        let last_page_addr = ((addr as i64 + buf.len() as i64 + 4095) & (-4096)) as mach_vm_address_t;
+            let page_size      = last_page_addr as usize - page_addr as usize;
 
-                let result = vm_read(task.unwrap(), addr as u64, buf.len() as u64, buf.as_mut_ptr(), &mut read);
-                if result != KERN_SUCCESS {
-                    return Err(io::Error::last_os_error())
-                }
+            let read_ptr: *mut u8 = ptr::null_mut();
+            let mut read_len: mach_msg_type_number_t = 0;
+
+            let result = unsafe {
+                vm_read(task.unwrap(), page_addr as u64, page_size as vm_size_t, &read_ptr, &mut read_len)
+            };
+
+            if result != KERN_SUCCESS {
+                // panic!("({}) {:?}", result, io::Error::last_os_error());
+                return Err(io::Error::last_os_error())
             }
+
+            if read_len != page_size as u32 {
+                panic!("Mismatched read sizes for `vm_read` (expected {}, got {})", page_size, read_len)
+            }
+
+            let read_buf = unsafe { slice::from_raw_parts(read_ptr, read_len as usize) };
+
+            let offset = addr - page_addr as usize;
+            let len = buf.len();
+            buf.copy_from_slice(&read_buf[offset..(offset + len)]);
 
             Ok(())
         }
@@ -139,6 +159,8 @@ mod platform {
 pub fn copy_address_raw<T>(addr: *const c_void, length: usize, source: &T) -> Vec<u8>
     where T: CopyAddress
 {
+    debug!("copy_address_raw: addr: {:x}", addr as usize);
+
     if length > 100000 {
         // something very unusual has happened.
         // Do not respect requests for huge amounts of memory.
@@ -254,6 +276,7 @@ fn get_maps_address(pid: pid_t) -> u64 {
     addr
 }
 
+#[cfg(target_os="linux")]
 pub fn get_ruby_current_thread_address(pid: pid_t) -> u64 {
     // Get the address of the `ruby_current_thread` global variable. It works
     // by looking up the address in the Ruby binary's symbol table with `nm
@@ -263,6 +286,16 @@ pub fn get_ruby_current_thread_address(pid: pid_t) -> u64 {
     // this program only works on Linux anyway because of process_vm_readv.
     //
     let addr = get_nm_address(pid) + get_maps_address(pid);
+    debug!("get_ruby_current_thread_address: {:x}", addr);
+    addr
+}
+
+#[cfg(target_os="macos")]
+pub fn get_ruby_current_thread_address(pid: pid_t) -> u64 {
+    // TODO: Make this actually look up the `__mh_execute_header` base
+    //   address in the binary via `nm`.
+    let base_address = 0x100000000;
+    let addr = get_nm_address(pid) + (get_maps_address(pid) - base_address);
     debug!("get_ruby_current_thread_address: {:x}", addr);
     addr
 }


### PR DESCRIPTION
Things to do:

- [x] Set up platform-specific modules with their own implementations of the `CopyAddress` trait in the `lib` module.
- [x] Actually verify Mac OS implementation of `CopyAddress` works.
- [x] Add platform-specific implementations of functions in `dwarf` module.
- [x] Verify those platform-specific implementations in `dwarf` work.