### PR TITLE
Use the new read-process-memory crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ gimli={git="https://github.com/fitzgen/gimli.git"}
 elf = "0.0.9"
 log = "0.3.6"
 env_logger = "0.3.4"
+read-process-memory = "0.1.0"
 
 [target.'cfg(target_os="macos")'.dependencies]
 mach = "0.0.5"

--- a/src/bin/ruby-stacktrace.rs
+++ b/src/bin/ruby-stacktrace.rs
@@ -6,6 +6,7 @@ extern crate ruby_stacktrace;
 extern crate byteorder;
 extern crate clap;
 extern crate env_logger;
+extern crate read_process_memory;
 
 use clap::{Arg, App, ArgMatches};
 use libc::*;
@@ -13,6 +14,7 @@ use std::process;
 use std::time::Duration;
 use std::thread;
 use std::collections::HashMap;
+use read_process_memory::*;
 
 use ruby_stacktrace::*;
 use ruby_stacktrace::dwarf::{create_lookup_table, get_dwarf_entries};
@@ -42,7 +44,7 @@ fn main() {
     let matches = parse_args();
     let pid: pid_t = matches.value_of("PID").unwrap().parse().unwrap();
     let command = matches.value_of("COMMAND").unwrap();
-    let source = Process::new(pid);
+    let source = pid.try_into_process_handle().unwrap();
     if command.clone() != "top" && command.clone() != "stackcollapse" && command.clone() != "parse" {
         println!("COMMAND must be 'top' or 'stackcollapse. Try again!");
         process::exit(1);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,10 +1,11 @@
+extern crate read_process_memory;
 extern crate elf;
 
 use std::io;
 
 use libc;
 
-use CopyAddress;
+use read_process_memory::CopyAddress;
 
 
 // Data for use in tests and benchmarks :-)
@@ -77,7 +78,7 @@ mod tests {
 
     use byteorder::{ReadBytesExt, LittleEndian};
 
-    use CopyAddress;
+    use read_process_memory::CopyAddress;
 
     use super::data::COREDUMP;
 


### PR DESCRIPTION
Hey! I wanted to use your process-memory-reading code for another project, so I split it out to a standalone crate:
https://github.com/luser/read-process-memory
https://crates.io/crates/read-process-memory

Here's a PR to remove that code from this project and make it use that crate instead. I even added a Windows implementation to that crate if you ever get strangely motivated to make ruby-stacktrace work on Windows. :)

While I was removing code I removed all but one of your `unsafe` blocks! I think some of them were probably just leftovers from previous hacking.