### PR TITLE
Mentions threads in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ process.
 
 I wrote a blog post about the internals at [How to spy on a Ruby process](http://jvns.ca/blog/2016/06/12/a-weird-system-call-process-vm-readv/)
 
+## Threads?
+
+It's enough to run this once on the PID and it will sample across all threads.
+
 ## Developing ruby-stacktrace
 
 It's written in Rust.


### PR DESCRIPTION
I was wondering whether this tool will capture all threads of a ruby process.
Seems yes: I wrote [simple code][1] with different functions eating cpu in 2 sub-threads, run ruby-stacktrace on both main PID and thread PIDs, and got same picture from all of them, showing both cpu-eating functions:

```
 self | tot  | method
 42.0% | 100.0% | work : /home/bpaskinc/work-in-subthread.rb
 30.0% | 13.5% | dumb_work : /home/bpaskinc/work-in-subthread.rb
 28.0% | 6.5% | block in dumb_work : /home/bpaskinc/work-in-subthread.rb
```

However I wonder about the numbers.
`work` shows as total 100% but it was only one thread.
`dumb_work` doesn't add up to nearly another 100%.  (I suspect because `Range#each` is written C?)
OK, so what if I add another `work` thread?

```
 self | tot  | method
 60.0% | 100.0% | work : /home/bpaskinc/work-in-subthread.rb
 21.0% | 3.4% | block in dumb_work : /home/bpaskinc/work-in-subthread.rb
 19.0% | 6.5% | dumb_work : /home/bpaskinc/work-in-subthread.rb
```

There is nothing here that adds up to ~300%, but it's not ~100% either...

So is there any statement that could be made in README about what the numbers mean with threads?

PS. @jvns thanks for this tool and generally making low-level things less scary :)

[1]: https://gist.github.com/cben/7b3926df260583fc1fd893bddd9d1897