### PR TITLE
Make it possible to profile a subprocess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.o
 target
-*.rb
 .ruby-version

--- a/examples/short_program.rb
+++ b/examples/short_program.rb
@@ -1,0 +1,13 @@
+def aaa() 
+    sleep(0.5)
+end
+
+def bbb() 
+    aaa()
+end
+
+def ccc() 
+    bbb()
+end
+
+ccc()

--- a/src/bin/ruby-stacktrace.rs
+++ b/src/bin/ruby-stacktrace.rs
@@ -9,48 +9,118 @@ extern crate clap;
 extern crate env_logger;
 extern crate read_process_memory;
 
-use clap::{Arg, App, ArgMatches};
+use clap::{Arg, App, ArgMatches, AppSettings};
 use libc::*;
 use std::process;
 use std::time::Duration;
 use std::thread;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::process::Command;
 
 use ruby_stacktrace::*;
 
-fn parse_args() -> ArgMatches<'static> {
+fn arg_parser() -> App<'static, 'static> {
     App::new("ruby-stacktrace")
         .version("0.1")
+        .setting(AppSettings::TrailingVarArg)
         .about("Sampling profiler for Ruby programs")
-        .arg(Arg::with_name("COMMAND")
-            .help("Subcommand you want to run. Options: top, stackcollapse.\n          top \
+        .arg(
+            Arg::with_name("SUBCOMMAND")
+                .help(
+                    "Subcommand you want to run. Options: top, stackcollapse.\n          top \
                    prints a top-like output of what the Ruby process is doing right now\n          \
                    stackcollapse prints out output suitable for piping to stackcollapse.pl \
-                   (https://github.com/brendangregg/FlameGraph)")
-            .required(true)
-            .index(1))
-        .arg(Arg::with_name("PID")
-            .help("PID of the Ruby process you want to profile")
-            .required(true)
-            .index(2))
-        .get_matches()
+                   (https://github.com/brendangregg/FlameGraph)",
+                )
+                .required(true)
+                .index(1),
+        )
+        .arg(
+            Arg::from_usage(
+                "-p --pid=[PID] 'PID of the Ruby process you want to profile'",
+            ).required_unless("cmd"),
+        )
+        .arg(Arg::from_usage("<cmd>... 'commands to run'").required(
+            false,
+        ))
 }
 
+fn parse_args() -> ArgMatches<'static> {
+    arg_parser().get_matches()
+}
+
+#[test]
+fn test_arg_parsing() {
+    let parser = arg_parser();
+    // let result = parser.get_matches_from(vec!("ruby-stacktrace", "stackcollapse", "-p", "1234"));
+    let result = parser.get_matches_from(vec!["ruby-stacktrace", "stackcollapse", "--pid", "1234"]);
+    assert!(result.value_of("pid").unwrap() == "1234");
+    assert!(result.value_of("SUBCOMMAND").unwrap() == "stackcollapse");
+
+    let parser = arg_parser();
+    let result = parser.get_matches_from(vec!["ruby-stacktrace", "--pid", "1234", "stackcollapse"]);
+    assert!(result.value_of("pid").unwrap() == "1234");
+    assert!(result.value_of("SUBCOMMAND").unwrap() == "stackcollapse");
+
+    let parser = arg_parser();
+    let result =
+        parser.get_matches_from(vec!["ruby-stacktrace", "stackcollapse", "ruby", "blah.rb"]);
+    let mut cmd_values = result.values_of("cmd").unwrap();
+    assert!(cmd_values.next().unwrap() == "ruby");
+    assert!(cmd_values.next().unwrap() == "blah.rb");
+    assert!(result.value_of("SUBCOMMAND").unwrap() == "stackcollapse");
+}
+
+
+fn get_current_address(pid: pid_t) -> u64 {
+    // this exists because sometimes rbenv takes a while to exec the right Ruby binary.
+    // we are dumb right now so we just... wait until it seems to work out.
+    let mut i = 0;
+    loop {
+        let location = address_finder::current_thread_address_location(pid);
+        if i > 100 {
+            break;
+        }
+        if location.is_ok() {
+            return location.unwrap();
+        }
+        // if it doesn't work, sleep for 1ms and try again
+        i += 1;
+        thread::sleep(Duration::from_millis(1));
+    }
+    panic!("Couldn't find ruby_current_thread");
+}
 
 fn main() {
     env_logger::init().unwrap();
 
     let matches = parse_args();
-    let pid: pid_t = matches.value_of("PID").unwrap().parse().unwrap();
-    let command = matches.value_of("COMMAND").unwrap();
+    let command = matches.value_of("SUBCOMMAND").unwrap();
+    let maybe_pid = matches.value_of("pid");
+    let pid: pid_t = match maybe_pid {
+        Some(x) => x.parse().unwrap(),
+        None => {
+            let mut args = matches.values_of("cmd").unwrap();
+            let arg1 = args.next().unwrap();
+            let pid = Command::new(arg1)
+                .args(args)
+                .spawn()
+                .expect("command failed to start")
+                .id() as pid_t;
+            pid
+        }
+
+    };
+
     if command.clone() != "top" && command.clone() != "stackcollapse" &&
-       command.clone() != "parse" {
+        command.clone() != "parse"
+    {
         println!("COMMAND must be 'top' or 'stackcollapse. Try again!");
         process::exit(1);
     }
 
-    let ruby_current_thread_address_location: u64 = address_finder::current_thread_address_location(pid).unwrap();
+    let ruby_current_thread_address_location: u64 = get_current_address(pid);
     let stack_trace_function = stack_trace::get_stack_trace_function(pid);
 
     if command == "parse" {
@@ -60,8 +130,8 @@ fn main() {
         // This gets a stack trace and then just prints it out
         // in a format that Brendan Gregg's stackcollapse.pl script understands
         loop {
-            let trace = stack_trace_function(ruby_current_thread_address_location, pid).unwrap_or_else(|x| {
-                println!("oh no {:?}", x);
+            let trace = stack_trace_function(ruby_current_thread_address_location, pid).unwrap_or_else(|_| {
+                // TODO: check that it's actually just a "process doesn't exist" error otherwise complain
                 process::exit(0);
             });
             user_interface::print_stack_trace(&trace);
@@ -76,9 +146,8 @@ fn main() {
         let mut j = 0;
         loop {
             j += 1;
-            let trace = stack_trace_function(ruby_current_thread_address_location, pid).unwrap_or_else(|_| {
-                process::exit(0);
-            });
+            let trace = stack_trace_function(ruby_current_thread_address_location, pid)
+                .unwrap_or_else(|_| { process::exit(0); });
             // only count each element in the stack trace once
             // otherwise recursive methods are overcounted
             let mut seen = HashSet::new();


### PR DESCRIPTION
This makes it possible to execute & profile a subprocess. This is important because it lets us profile processes without being root -- if you exec a subprocess, then you can `process_vm_readv` that subprocess even if you're unprivileged.