### PR TITLE
Improvements to integration tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,19 +2,22 @@ set -u
 
 set -e
 env CARGO_INCREMENTAL=1 cargo build
-cp target/debug/ruby-stacktrace docker/
-cp examples/short_program.rb docker/
+rm -rf /tmp/artifacts
+mkdir /tmp/artifacts
+cp target/debug/ruby-stacktrace /tmp/artifacts
+cp examples/short_program.rb /tmp/artifacts
+cp examples/infinite.rb /tmp/artifacts
 set +e
 
+rm -f /tmp/output
+touch /tmp/output
 for distro in ubuntu1604 ubuntu1404 fedora
 do
    echo "Distro: $distro"
-   rm -f /tmp/output
-   touch /tmp/output
    echo "Building Dockerfile..."
    docker build -t rb-stracktrace-$distro -f ./docker/Dockerfile.$distro  ./docker/ >> /tmp/output 2>&1
    echo "Running rbenv 2.3.1..."
-   docker run -t rb-stacktrace-ubuntu1404 env PATH=/root/.rbenv/shims:/usr/bin:/bin RUST_BACKTRACE=1 RBENV_VERSION=2.3.1 /stuff/ruby-stacktrace stackcollapse ruby /stuff/short_program.rb >> /tmp/output 2>&1
+   docker run -v=/tmp/artifacts:/stuff -t rb-stacktrace-$distro  env PATH=/root/.rbenv/shims:/usr/bin:/bin RUST_LOG=debug RUST_BACKTRACE=1 RBENV_VERSION=2.3.1 /stuff/ruby-stacktrace stackcollapse ruby /stuff/short_program.rb >> /tmp/output 2>&1
    if [ $? -eq 0 ]
    then
        echo "Success!"
@@ -22,7 +25,7 @@ do
        echo "Failure!"
    fi
    echo "Running system ruby..."
-   docker run -t rb-stacktrace-ubuntu1404 env RUST_BACKTRACE=1 /stuff/ruby-stacktrace stackcollapse /usr/bin/ruby /stuff/short_program.rb >> /tmp/output 2>&1
+   docker run -v=/tmp/artifacts:/stuff -t rb-stacktrace-$distro  env RUST_LOG=debug RUST_BACKTRACE=1 /stuff/ruby-stacktrace stackcollapse /usr/bin/ruby /stuff/short_program.rb >> /tmp/output 2>&1
    if [ $? -eq 0 ]
    then
        echo "Success!"

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -18,4 +18,3 @@ ADD ./versions.txt /root/versions.txt
 RUN rbenv install 2.3.5
  
 ENV PATH /root/.rbenv/shims:$PATH
-ADD ./ /stuff

--- a/docker/Dockerfile.ubuntu1404
+++ b/docker/Dockerfile.ubuntu1404
@@ -22,4 +22,3 @@ ADD ./versions.txt /root/versions.txt
 RUN xargs -L 1 rbenv install < /root/versions.txt
  
 ENV PATH /root/.rbenv/shims:$PATH
-ADD . /stuff

--- a/docker/Dockerfile.ubuntu1604
+++ b/docker/Dockerfile.ubuntu1604
@@ -24,4 +24,3 @@ RUN xargs -L 1 rbenv install < /root/versions.txt
 RUN apt-get install -y --force-yes ruby2.3
 
 ENV PATH /root/.rbenv/shims:$PATH
-ADD ./ /stuff


### PR DESCRIPTION
2 improvements to the integration tests:

* fixes a bug where it was always using the ubuntu 14.04 docker image when running the tests instead of using the appropriate distro image
* store all the build artifacts shared with the docker image in /tmp/artifacts instead of in the docker/ directory